### PR TITLE
商品一覧表示、商品がなければダミー商品表示

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
+    @items = Item.includes(:user).order("created_at DESC")
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,38 +125,38 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item|%>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to root_path(item) do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %> 
 
           <%# 商品が売れていればsold outを表示しましょう %>
+          <%# <% if item.present? %> 
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
+          <%# <% end %> 
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.burden.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
+              <% end %>
             </div>
           </div>
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <%# 商品がなければダミーの商品を表示 %>
+      <% unless @items.present? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -173,9 +173,8 @@
           </div>
         </div>
         <% end %>
+        <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,7 +127,7 @@
     <ul class='item-lists'>
       <% @items.each do |item|%>
       <li class='list'>
-        <%= link_to root_path(item) do %>
+        <%= link_to '#' do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %> 
 
@@ -153,8 +153,8 @@
             </div>
           </div>
         </div>
-        <% end %>
       </li>
+      <% end %>
       <%# 商品がなければダミーの商品を表示 %>
       <% unless @items.present? %>
       <li class='list'>
@@ -173,8 +173,8 @@
           </div>
         </div>
         <% end %>
-        <% end %>
       </li>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>


### PR DESCRIPTION
# What
商品一覧表示機能

# Why
・出品した商品を一覧表示するため
・投稿した商品の「画像/価格/商品名/配送料」負担が表示されている。

・商品のデータがない場合、ダミー商品が表示されている
https://gyazo.com/c2c6953707988f10ce9b27a55f6dfb9c
・商品のデータがある場合は、商品が一覧表示されている。
https://gyazo.com/fa8822a927d7ef577843d6c2444ecb29
